### PR TITLE
fix: registry normalization in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,12 +24,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "docker_credential"
 version = "1.0.1"
 dependencies = [
  "base64",
+ "rstest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+
+[[package]]
+name = "futures-task"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -31,6 +139,24 @@ name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -42,12 +168,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 0.4.27",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2 1.0.47",
+]
+
+[[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rustc_version",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -55,6 +233,12 @@ name = "ryu"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -71,9 +255,9 @@ version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 0.4.27",
+ "quote 0.6.11",
+ "syn 0.15.30",
 ]
 
 [[package]]
@@ -88,15 +272,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c8865bf5a7cbb662d8b011950060b3c8743dca141b054bf7195b20d314d8e2"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 0.4.27",
+ "quote 0.6.11",
  "unicode-xid",
 ]
+
+[[package]]
+name = "syn"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ travis-ci = { repository = "keirlawson/docker_credential" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.10.1"
+
+[dev-dependencies]
+rstest = "0.15.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,11 +18,22 @@ pub(crate) struct DockerConfig {
 }
 
 impl DockerConfig {
-    pub fn get_auth(&self, server: &str) -> Option<&String> {
-        self.auths
-            .as_ref()
-            .and_then(|auths| auths.get(server))
-            .and_then(|auth_config| auth_config.auth.as_ref())
+    pub fn get_auth(&self, image_registry: &str) -> Option<&String> {
+        if let Some(auths) = &self.auths {
+            if let Some(credential) = auths.get(image_registry) {
+                return credential.auth.as_ref();
+            }
+
+            let image_registry = normalize_registry(image_registry);
+            if let Some((_, auth_str)) = auths
+                .iter()
+                .find(|(key, _)| normalize_key_to_registry(key) == image_registry)
+            {
+                return auth_str.auth.as_ref();
+            }
+        }
+
+        None
     }
 
     pub fn get_helper(&self, server: &str) -> Option<&String> {
@@ -38,4 +49,36 @@ pub(crate) fn read_config(config_dir: &Path) -> Result<DockerConfig> {
     let f = File::open(config_path).map_err(|_| CredentialRetrievalError::ConfigReadError)?;
 
     serde_json::from_reader(f).map_err(|_| CredentialRetrievalError::ConfigReadError)
+}
+
+/// Normalizes a given key (image reference) into its resulting registry
+fn normalize_key_to_registry(key: &str) -> &str {
+    let stripped = key.strip_prefix("http://").unwrap_or(key);
+    let mut stripped = key.strip_prefix("https://").unwrap_or(stripped);
+    if stripped != key {
+        stripped = stripped.split_once('/').unwrap_or((stripped, "")).0;
+    }
+
+    normalize_registry(stripped)
+}
+
+/// Converts the provided registry if a known `docker.io` host
+/// is provided.
+fn normalize_registry(registry: &str) -> &str {
+    match registry {
+        "registry-1.docker.io" | "docker.io" => "index.docker.io",
+        _ => registry,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[rstest::rstest]
+    #[case("https://index.docker.io/v1/", "index.docker.io")]
+    #[case("https://docker.io/v1/", "index.docker.io")]
+    #[case("quay.io", "quay.io")]
+    fn test_normalize_key_to_registry(#[case] key: &str, #[case] expected: &str) {
+        let registry = super::normalize_key_to_registry(key);
+        assert_eq!(registry, expected);
+    }
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -34,7 +34,7 @@ fn response_from_helper(address: &str, helper: &str) -> Result<HelperResponse> {
     if output.status.success() {
         let parsed = serde_json::from_slice(&output.stdout)
             .map_err(|_| CredentialRetrievalError::MalformedHelperResponse)?;
-        return Ok(parsed);
+        Ok(parsed)
     } else {
         Err(CredentialRetrievalError::HelperFailure)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 mod config;
 mod helper;
 
-use base64;
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -87,7 +86,7 @@ where
     }
 
     if let Some(auth) = conf.get_auth(server) {
-        return Ok(decode_auth(&auth)?);
+        return decode_auth(auth);
     }
 
     if let Some(store_name) = conf.creds_store {


### PR DESCRIPTION
This PR includes the following:
* Normalizing registry name `"registry-1.docker.io"`, `"dockerhub.io"` to `"index.docker.io"`
* `lint fixes using cargo fmt` and `cargo clippy`