### PR TITLE
tolerate empty `credsHelper` in docker config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ impl DockerConfig {
     pub fn get_helper(&self, server: &str) -> Option<&String> {
         self.cred_helpers
             .as_ref()
-            .and_then(|helpers| helpers.get(server))
+            .and_then(|helpers| helpers.get(server).filter(|s| !s.is_empty()))
     }
 }
 


### PR DESCRIPTION
Helps with an issue we noticed in https://github.com/kubecfg/kubit/issues/260

A `credsHelper` field can be blank and still a valid Docker configuration file, at the moment this will panic and return a `HelperCommunicationError`.

For example, using GCP's Artifact registry:


We'll put this file into `/tmp/.docker-with-blank-helper/config.json`

```json
{
	"auths": {
		"us-docker.pkg.dev": {
			"auth": "c29tZV91c2VyOmZha2UK"
		}
	},
	"credHelpers": {
		"us-docker.pkg.dev": ""
	}
}
```

Without the `.filter()` check onto the `Option`, we get back a `Some("")` which then proceeds to run through the rest of the checks, but with the blank `helper_name` - when it tries to look for this its not valid as we would expect.

Using the `README.md` example code:

```
DOCKER_CONFIG="/tmp/.docker-with-blank-helper" cargo run
   Compiling docker_credential v1.2.0 (/home/influx/work/jdockerty-docker-credential)
   Compiling rust-playground v0.1.0 (/home/influx/work/rust-playground)
    Finished dev [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/rust-playground`
thread 'main' panicked at 'Unable to retrieve credential: HelperCommunicationError', src/main.rs:6:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By filtering over the blank value, which is valid but does not require a call out to a helper, we get a successful response. This is because the `.get` to the `HashMap` instead returns with a `None` response, meaning that the use of a credential helper is skipped over, even though the field is populated as we know that the blank value is not desirable yet still a valid configuration.

```
DOCKER_CONFIG="/tmp/.docker-with-blank-helper" cargo run
   Compiling docker_credential v1.2.0 (/home/influx/work/jdockerty-docker-credential)
   Compiling rust-playground v0.1.0 (/home/influx/work/rust-playground)
    Finished dev [unoptimized + debuginfo] target(s) in 0.36s
     Running `target/debug/rust-playground`
Username: some_user, Password: fake
```
