### PR TITLE
feat: add support for readers, add podman auth.json support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,7 @@
 use super::{CredentialRetrievalError, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fs::File;
-use std::path::Path;
+use std::io::Read;
 
 #[derive(Deserialize)]
 pub(crate) struct AuthConfig {
@@ -43,12 +42,8 @@ impl DockerConfig {
     }
 }
 
-pub(crate) fn read_config(config_dir: &Path) -> Result<DockerConfig> {
-    let config_path = config_dir.join("config.json");
-
-    let f = File::open(config_path).map_err(|_| CredentialRetrievalError::ConfigReadError)?;
-
-    serde_json::from_reader(f).map_err(|_| CredentialRetrievalError::ConfigReadError)
+pub(crate) fn read_config(reader: impl Read) -> Result<DockerConfig> {
+    serde_json::from_reader(reader).map_err(|_| CredentialRetrievalError::ConfigReadError)
 }
 
 /// Normalizes a given key (image reference) into its resulting registry


### PR DESCRIPTION
Hello, I  added a `get_credential_from_reader` function that allows the user to load credentials from an arbitrary reader. This will allow for arbitrary config.json file resolution. The existing `get_credential` function uses this function internally. I've wrapped the file stream in a BufReader to potentially reduce the amount of syscalls.

Next I've added the `get_podman_credential` function that resolves the `auth.json` file and reads the credential from it. The lookup is performed in the [documented way](https://docs.podman.io/en/stable/markdown/podman-login.1.html#authfile-path). I did not hide this function behind a feature flag, because it's footprint is very small. I believe it's valid to hide it if you deem that to be necessary though.

Finally I've resolved some minor clippy warnings about unecessary owned objects, etc.