### PR TITLE
feat: support identity token field for auth config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::io::Read;
 #[derive(Deserialize)]
 pub(crate) struct AuthConfig {
     pub(crate) auth: Option<String>,
+    pub(crate) identitytoken: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -29,6 +30,24 @@ impl DockerConfig {
                 .find(|(key, _)| normalize_key_to_registry(key) == image_registry)
             {
                 return auth_str.auth.as_ref();
+            }
+        }
+
+        None
+    }
+
+    pub fn get_identity_token(&self, image_registry: &str) -> Option<&String> {
+        if let Some(auths) = &self.auths {
+            if let Some(auth_config) = auths.get(image_registry) {
+                return auth_config.identitytoken.as_ref();
+            }
+
+            let image_registry = normalize_registry(image_registry);
+            if let Some((_, auth_config)) = auths
+                .iter()
+                .find(|(key, _)| normalize_key_to_registry(key) == image_registry)
+            {
+                return auth_config.identitytoken.as_ref();
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,10 @@ where
         return from_helper(server, helper_name);
     }
 
+    if let Some(identity_token) = conf.get_identity_token(server) {
+        return Ok(DockerCredential::IdentityToken(identity_token.to_string()));
+    }
+
     if let Some(auth) = conf.get_auth(server) {
         return decode_auth(auth);
     }
@@ -231,6 +235,7 @@ mod tests {
             String::from("some server"),
             config::AuthConfig {
                 auth: Some(encoded_auth),
+                identitytoken: None,
             },
         );
         let auth_config = config::DockerConfig {
@@ -266,6 +271,7 @@ mod tests {
                 String::from("some server"),
                 config::AuthConfig {
                     auth: Some(encoded_auth),
+                    identitytoken: None,
                 },
             )]);
 


### PR DESCRIPTION
Add support for [identityToken](https://github.com/moby/moby/blob/master/api/types/registry/authconfig.go#L30) field to [AuthConfig](https://github.com/keirlawson/docker_credential/blob/master/src/config.rs#L7)

Fixes: https://github.com/keirlawson/docker_credential/issues/13