### PR TITLE
Which helper returned error?

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -12,7 +12,7 @@ struct HelperResponse {
 
 fn response_from_helper(address: &str, helper: &str) -> Result<HelperResponse> {
     let full_helper_name = format!("docker-credential-{}", helper);
-    let mut process = Command::new(full_helper_name)
+    let mut process = Command::new(&full_helper_name)
         .arg("get")
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
@@ -37,6 +37,7 @@ fn response_from_helper(address: &str, helper: &str) -> Result<HelperResponse> {
         Ok(parsed)
     } else {
         Err(CredentialRetrievalError::HelperFailure {
+            helper: full_helper_name,
             stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,11 @@ type Result<T> = std::result::Result<T, CredentialRetrievalError>;
 pub enum CredentialRetrievalError {
     HelperCommunicationError,
     MalformedHelperResponse,
-    HelperFailure { stdout: String, stderr: String },
+    HelperFailure {
+        helper: String,
+        stdout: String,
+        stderr: String,
+    },
     CredentialDecodingError,
     NoCredentialConfigured,
     ConfigNotFound,
@@ -34,10 +38,14 @@ impl fmt::Display for CredentialRetrievalError {
             CredentialRetrievalError::MalformedHelperResponse => {
                 write!(f, "Credential helper response malformed")
             }
-            CredentialRetrievalError::HelperFailure { stdout, stderr } => {
+            CredentialRetrievalError::HelperFailure {
+                helper,
+                stdout,
+                stderr,
+            } => {
                 write!(
                     f,
-                    "Credential helper returned non-zero response code:\n\
+                    "Credential helper `{helper}` returned non-zero response code:\n\
                     stdout:\n{stdout}\n\n\
                     stderr:\n{stderr}\n",
                 )


### PR DESCRIPTION
Using `oci-client`

```
cargo run --example get-manifest -- docker.io/library/alpine
```

Before:

```
thread 'main' panicked at examples/get-manifest/main.rs:47:19:
Error handling docker configuration file: Credential helper returned non-zero response code:
stdout:
credentials not found in native keychain


stderr:
```

After:

```
thread 'main' panicked at examples/get-manifest/main.rs:47:19:
Error handling docker configuration file: Credential helper `docker-credential-desktop` returned non-zero response code:
stdout:
credentials not found in native keychain


stderr:
```

It is still wrong, but at least I know which command failed. Especially important because I have three: `docker-credential-desktop`, `docker-credential-gcloud` and `docker-credential-osxkeychain`.