### PR TITLE
fix: handle docker config with plain username/password fields

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use std::io::Read;
 #[derive(Deserialize)]
 pub(crate) struct AuthConfig {
     pub(crate) auth: Option<String>,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
     pub(crate) identitytoken: Option<String>,
 }
 
@@ -48,6 +50,28 @@ impl DockerConfig {
                 .find(|(key, _)| normalize_key_to_registry(key) == image_registry)
             {
                 return auth_config.identitytoken.as_ref();
+            }
+        }
+
+        None
+    }
+
+    pub fn get_username_password(&self, image_registry: &str) -> Option<(&String, &String)> {
+        if let Some(auths) = &self.auths {
+            if let Some(credential) = auths.get(image_registry) {
+                if let (Some(u), Some(p)) = (&credential.username, &credential.password) {
+                    return Some((u, p));
+                }
+            }
+
+            let image_registry = normalize_registry(image_registry);
+            if let Some((_, auth_config)) = auths
+                .iter()
+                .find(|(key, _)| normalize_key_to_registry(key) == image_registry)
+            {
+                if let (Some(u), Some(p)) = (&auth_config.username, &auth_config.password) {
+                    return Some((u, p));
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub enum CredentialRetrievalError {
         stderr: String,
     },
     CredentialDecodingError,
+    CredentialMismatchError,
     NoCredentialConfigured,
     ConfigNotFound,
     ConfigReadError,
@@ -52,6 +53,12 @@ impl fmt::Display for CredentialRetrievalError {
             }
             CredentialRetrievalError::CredentialDecodingError => {
                 write!(f, "Unable to decode credential")
+            }
+            CredentialRetrievalError::CredentialMismatchError => {
+                write!(
+                    f,
+                    "auth field does not match username and password fields"
+                )
             }
             CredentialRetrievalError::NoCredentialConfigured => {
                 write!(f, "User has no credential configured")
@@ -116,7 +123,22 @@ where
     }
 
     if let Some(auth) = conf.get_auth(server) {
-        return decode_auth(auth);
+        let credential = decode_auth(auth)?;
+        if let Some((username, password)) = conf.get_username_password(server) {
+            // Both auth and username/password are present: verify they are consistent
+            let expected = DockerCredential::UsernamePassword(username.clone(), password.clone());
+            if credential != expected {
+                return Err(CredentialRetrievalError::CredentialMismatchError);
+            }
+        }
+        return Ok(credential);
+    }
+
+    if let Some((username, password)) = conf.get_username_password(server) {
+        return Ok(DockerCredential::UsernamePassword(
+            username.clone(),
+            password.clone(),
+        ));
     }
 
     if let Some(store_name) = conf.creds_store {
@@ -243,6 +265,8 @@ mod tests {
             String::from("some server"),
             config::AuthConfig {
                 auth: Some(encoded_auth),
+                username: None,
+                password: None,
                 identitytoken: None,
             },
         );
@@ -279,6 +303,8 @@ mod tests {
                 String::from("some server"),
                 config::AuthConfig {
                     auth: Some(encoded_auth),
+                    username: None,
+                    password: None,
                     identitytoken: None,
                 },
             )]);
@@ -353,5 +379,91 @@ mod tests {
                 "expected_token"
             )))
         );
+    }
+
+    #[test]
+    fn plain_username_password_no_auth() {
+        let auths = HashMap::from([(
+            String::from("some server"),
+            config::AuthConfig {
+                auth: None,
+                username: Some(String::from("some_user")),
+                password: Some(String::from("some_password")),
+                identitytoken: None,
+            },
+        )]);
+        let auth_config = config::DockerConfig {
+            auths: Some(auths),
+            creds_store: None,
+            cred_helpers: None,
+        };
+        let dummy_helper =
+            |_: &str, _: &str| Err(CredentialRetrievalError::HelperCommunicationError);
+        let result = extract_credential(auth_config, "some server", dummy_helper);
+
+        assert_eq!(
+            result,
+            Ok(DockerCredential::UsernamePassword(
+                String::from("some_user"),
+                String::from("some_password")
+            ))
+        );
+    }
+
+    #[test]
+    fn auth_matches_username_password() {
+        let encoded_auth =
+            general_purpose::STANDARD_NO_PAD.encode("some_user:some_password");
+        let auths = HashMap::from([(
+            String::from("some server"),
+            config::AuthConfig {
+                auth: Some(encoded_auth),
+                username: Some(String::from("some_user")),
+                password: Some(String::from("some_password")),
+                identitytoken: None,
+            },
+        )]);
+        let auth_config = config::DockerConfig {
+            auths: Some(auths),
+            creds_store: None,
+            cred_helpers: None,
+        };
+        let dummy_helper =
+            |_: &str, _: &str| Err(CredentialRetrievalError::HelperCommunicationError);
+        let result = extract_credential(auth_config, "some server", dummy_helper);
+
+        assert_eq!(
+            result,
+            Ok(DockerCredential::UsernamePassword(
+                String::from("some_user"),
+                String::from("some_password")
+            ))
+        );
+    }
+
+    #[test]
+    fn auth_mismatches_username_password() {
+        // auth encodes different credentials than username/password fields
+        let encoded_auth =
+            general_purpose::STANDARD_NO_PAD.encode("other_user:other_password");
+        let auths = HashMap::from([(
+            String::from("some server"),
+            config::AuthConfig {
+                auth: Some(encoded_auth),
+                username: Some(String::from("some_user")),
+                password: Some(String::from("some_password")),
+                identitytoken: None,
+            },
+        )]);
+        let auth_config = config::DockerConfig {
+            auths: Some(auths),
+            creds_store: None,
+            cred_helpers: None,
+        };
+        let dummy_helper =
+            |_: &str, _: &str| Err(CredentialRetrievalError::HelperCommunicationError);
+        let result = extract_credential(auth_config, "some server", dummy_helper);
+
+        assert_eq!(result, Err(CredentialRetrievalError::CredentialMismatchError));
     }
 }


### PR DESCRIPTION
Docker's config.json supports storing credentials as separate username and password fields, not only as a base64-encoded auth string.

Handle the case where docker config file contains only username and password fields, and no auth field.

When all three fields are present, validate that the auth field decodes consistently with the username and password.
